### PR TITLE
Fix "Build task 'ojs:js-watch' MUST depend to 'ojs:locale-build'"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "outlinejs",
-  "version": "1.3.33",
+  "version": "1.3.34",
   "description": "Javascript App Outline",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/src/utils/build/tasks.js
+++ b/src/utils/build/tasks.js
@@ -182,7 +182,7 @@ export default class {
       return merge2(clientBundle, serverBundle);
     });
 
-    this.gulp.task('ojs:js-watch', ['ojs:node-html', 'ojs:env'], () => {
+    this.gulp.task('ojs:js-watch', ['ojs:node-html', 'ojs:env', 'ojs:locale-build'], () => {
       var bc = this.getBrowserify(true, false, true);
       var bs = this.getBrowserify(true, true, true);
       var clientBundle = this.getBrowserifyBundle(bc);


### PR DESCRIPTION
Fix of issue https://github.com/outlinejs/outlinejs/issues/17