### PR TITLE
Fix object.assign for option headers

### DIFF
--- a/src/utils/patches/backbone.js
+++ b/src/utils/patches/backbone.js
@@ -85,7 +85,7 @@ export function backboneSync(method, model, options) {
     }
 
     if (options.headers) {
-      params.headers = Object.assign(options.headers, params.headers);
+      params.headers = Object.assign(params.headers, options.headers);
     }
 
     if (params.method === 'GET') {


### PR DESCRIPTION
Object.assign(target, ...sources). Target is params.headers and sources are the new options.headers.